### PR TITLE
Fixing JFreeChart error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,5 +130,20 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>


### PR DESCRIPTION
The problem came from missing libraries in the created .jar file. One way to fix it is to specify the classpath when calling the jar. 

Another approach is to create an uber-jar containing everything, the approach chosen here. This is done via the `maven-shade-plugin`. The creates a bigger jar (12Mb instead of 1Mb), but this jar contains everything and can be distributed alone.

I didn't have to downgrade JFreeChart and the bug is fixed.

Closing #11 

(I still have a lot to learn on Maven and Java :) ) 