### PR TITLE
Wrapper for R

### DIFF
--- a/rwrapper/examples.R
+++ b/rwrapper/examples.R
@@ -1,0 +1,24 @@
+# Simple example based on EndToEndTest.java
+source("subdisc.R")
+
+testdatafile = "../src/test/resources/adult.txt"
+
+
+testAdult1 <- .subdisc.single_nominal.cortana_quality(
+  src = testdatafile,
+  targetColumn = 14,
+  targetValue = "gr50K"
+)
+
+print(.subdisc.SubgroupSet.tibble(testAdult1))
+
+
+
+testAdult2 <- .subdisc.single_numeric.explained_variance(
+  src = testdatafile,
+  targetColumn = 0,
+)
+
+print(.subdisc.SubgroupSet.tibble(testAdult2))
+
+

--- a/rwrapper/subdisc.R
+++ b/rwrapper/subdisc.R
@@ -1,0 +1,235 @@
+library(rJava)
+library(tibble)
+
+.jinit("../target/cortana-1.x.x.jar")
+
+
+# Factory function to load Java enum
+.jnewEnum <- function(enumclass){
+  function(name){.jfield(enumclass, paste("L", enumclass, ";", sep=""), name)}
+}
+
+# Java enum
+.subdisc.TargetType             <- .jnewEnum("nl/liacs/subdisc/TargetType")
+.subdisc.SearchStrategy         <- .jnewEnum("nl/liacs/subdisc/SearchStrategy")
+.subdisc.NumericOperatorSetting <- .jnewEnum("nl/liacs/subdisc/NumericOperatorSetting")
+.subdisc.NumericStrategy        <- .jnewEnum("nl/liacs/subdisc/NumericStrategy")
+.subdisc.QualityMeasure         <- .jnewEnum("nl/liacs/subdisc/QM")
+
+
+# General function to call a search
+
+subgroupdiscovery <- function(
+  src,
+  targetColumn,
+  targetValue = NULL,
+  targetType = .subdisc.TargetType("SINGLE_NOMINAL"),
+  qualityMeasure = .subdisc.QualityMeasure("CORTANA_QUALITY"),
+  qualityMeasureMinimum = NULL,
+  searchDepth = NULL,
+  minimumCoverage = NULL,
+  maximumCoverageFraction = NULL,
+  maximumSubgroups = NULL,
+  maximumTime = NULL,
+  searchStrategy = .subdisc.SearchStrategy("BEAM"),
+  nominalSets = NULL,
+  numericOperatorSetting = .subdisc.NumericOperatorSetting("NORMAL"),
+  numericStrategy = .subdisc.NumericStrategy("NUMERIC_BEST"),
+  searchStrategyWidth = NULL,
+  nrBins = NULL,
+  nrThreads = 1
+){
+  
+  # Loading the data table ----
+  # Only from file implemented
+  if(is.character(src)){
+    file <- .jnew("java.io.File", src)
+    loader <- .jnew("nl.liacs.subdisc.DataLoaderTXT", file)
+    dataTable <- J(loader, "getTable")
+    
+  } else {
+    print("Error: `src` is not valid")
+    return(Null)
+  }
+  
+  # Setting the target and target concept ----
+  target = .jcall(dataTable, 
+                  "Lnl/liacs/subdisc/Column;", 
+                  "getColumn", 
+                  as.integer(targetColumn))
+
+  targetConcept <- .jnew("nl.liacs.subdisc.TargetConcept")
+  
+  setTC <- function(func, value, typefunc=identity){
+    if(!is.null(value)){ .jcall(targetConcept, "V", func, typefunc(value)) }
+  }
+  
+  setTC( "setPrimaryTarget", target                    )
+  setTC( "setTargetType"   , targetType                )
+  setTC( "setTargetValue"  , targetValue, as.character )
+  
+  
+  # Setting the search parameters ----
+  searchParameters <- .jnew("nl.liacs.subdisc.SearchParameters")
+  
+  setSP <- function(func, value, typefunc=identity){
+    if(!is.null(value)){ .jcall(searchParameters, "V", func, typefunc(value)) }
+  }
+  
+  setSP( "setTargetConcept"          , targetConcept                       )
+  setSP( "setQualityMeasure"         , qualityMeasure                      )
+  setSP( "setQualityMeasureMinimum"  , qualityMeasureMinimum  , .jfloat    )
+  setSP( "setSearchDepth"            , searchDepth            , as.integer )
+  setSP( "setMinimumCoverage"        , minimumCoverage        , as.integer )
+  setSP( "setMaximumCoverageFraction", maximumCoverageFraction, .jfloat    )
+  setSP( "setMaximumSubgroups"       , maximumSubgroups       , as.integer )
+  setSP( "setMaximumTime"            , maximumTime            , .jfloat    )
+  setSP( "setSearchStrategy"         , searchStrategy                      )
+  setSP( "setNominalSets"            , nominalSets                         ) 
+  setSP( "setNumericOperators"       , numericOperatorSetting              )
+  setSP( "setNumericStrategy"        , numericStrategy                     )
+  setSP( "setSearchStrategyWidth"    , searchStrategyWidth    , as.integer )
+  setSP( "setNrBins"                 , nrBins                 , as.integer )
+  setSP( "setNrThreads"              , nrThreads              , as.integer )
+  
+
+  # The actual search call ----
+  subgroups <- .jcall(
+    obj = "nl.liacs.subdisc.Process", 
+    returnSig = "Lnl/liacs/subdisc/SubgroupDiscovery;", 
+    method = "runSubgroupDiscovery",
+    dataTable,                     # nl.liacs.subdisc.Table theTable
+    as.integer(0),                 # int theFold
+    .jnull("java.util.BitSet"),    # java.util.BitSet theSelection
+    searchParameters,              # nl.liacs.subdisc.SearchParameters theSearchParameters
+    FALSE,                         # boolean showWindows
+    as.integer(nrThreads),         # int theNrThreads
+    .jnull("javax.swing.JFrame")   # javax.swing.JFrame theMainWindow
+  )
+  
+  # Returning the results array
+  .jcall(subgroups, "Lnl/liacs/subdisc/SubgroupSet;", "getResult")
+}
+
+
+# Functions to extract the information from the SubgroupSet ----
+
+
+newGetFunc <- function(getFunc, returnType){
+  singleDispatch <- function(obj){ .jcall(obj, returnType, getFunc) }
+  function(objVec){ sapply(objVec, singleDispatch) }
+} 
+
+.subdisc.getString             <- newGetFunc("toString",              "S")
+.subdisc.getCoverage           <- newGetFunc("getCoverage",           "I")
+.subdisc.getDepth              <- newGetFunc("getDepth",              "I") 
+.subdisc.getFalsePositiveRate  <- newGetFunc("getFalsePositiveRate",  "D")
+.subdisc.getID                 <- newGetFunc("getID",                 "I") 
+.subdisc.getMeasureValue       <- newGetFunc("getMeasureValue",       "D")
+.subdisc.getPValue             <- newGetFunc("getPValue",             "D")
+.subdisc.getSecondaryStatistic <- newGetFunc("getSecondaryStatistic", "D") 
+.subdisc.getTeriaryStatistic   <- newGetFunc("getTertiaryStatistic",  "D") 
+.subdisc.getTruePositiveRate   <- newGetFunc("getTruePositiveRate",   "D") 
+
+#TODO: Handle Java String
+#.subdisc.getRegressionModel    <- newGetFunc("RegressionModel",    "S")
+
+
+# Function to create the tibble (dataframe)
+.subdisc.SubgroupSet.tibble <- function(subgroupset){
+  
+  sglist = as.list(subgroupset)
+  tibble(
+    Subgroup           = .subdisc.getString(sglist),
+    Coverage           = .subdisc.getCoverage(sglist),
+    Depth              = .subdisc.getDepth(sglist),
+    FalsePositiveRate  = .subdisc.getFalsePositiveRate(sglist),
+    ID                 = .subdisc.getID(sglist),
+    MeasureValue       = .subdisc.getMeasureValue(sglist),
+    PValue             = .subdisc.getPValue(sglist),
+    #RegressionModel    = .subdisc.getRegressionModel(sglist) # problem with java string
+    SecondaryStatistic = .subdisc.getSecondaryStatistic(sglist),
+    TertiaryStatistic  = .subdisc.getTeriaryStatistic(sglist),
+    TruePositiveRare   = .subdisc.getTruePositiveRate(sglist)
+  )
+}
+
+# Helper functions to specific search
+
+.subdisc.single_nominal.cortana_quality <- function(
+  src,
+  targetColumn,
+  targetValue,
+  qualityMeasureMinimum = 0.1,
+  searchDepth = 1,
+  minimumCoverage = 2,
+  maximumCoverageFraction = 1.0,
+  maximumSubgroups = 1000,
+  maximumTime = 1000,
+  searchStrategy = .subdisc.SearchStrategy("BEAM"),
+  nominalSets = FALSE,
+  numericOperatorSetting = .subdisc.NumericOperatorSetting("NORMAL"),
+  numericStrategy = .subdisc.NumericStrategy("NUMERIC_BEST"),
+  searchStrategyWidth = 10,
+  nrBins = 8,
+  nrThreads = 1
+){
+  subgroupdiscovery(
+    src = src,
+    targetColumn = targetColumn,
+    targetValue = targetValue,
+    targetType = .subdisc.TargetType("SINGLE_NOMINAL"),
+    qualityMeasure = .subdisc.QualityMeasure("CORTANA_QUALITY"),
+    qualityMeasureMinimum = qualityMeasureMinimum,
+    searchDepth = searchDepth,
+    minimumCoverage = minimumCoverage,
+    maximumCoverageFraction = maximumCoverageFraction,
+    maximumSubgroups = maximumSubgroups,
+    maximumTime = maximumTime,
+    searchStrategy = searchStrategy,
+    nominalSets = nominalSets,
+    numericOperatorSetting = numericOperatorSetting,
+    numericStrategy = numericStrategy,
+    searchStrategyWidth = searchStrategyWidth,
+    nrBins = nrBins,
+    nrThreads = nrThreads
+  )
+}
+
+.subdisc.single_numeric.explained_variance <- function(
+  src,
+  targetColumn,
+  qualityMeasureMinimum = 0.1,
+  searchDepth = 1,
+  minimumCoverage = 2,
+  maximumCoverageFraction = 1.0,
+  maximumSubgroups = 1000,
+  maximumTime = 1000,
+  searchStrategy = .subdisc.SearchStrategy("BEAM"),
+  nominalSets = FALSE,
+  numericOperatorSetting = .subdisc.NumericOperatorSetting("NORMAL"),
+  numericStrategy = .subdisc.NumericStrategy("NUMERIC_BEST"),
+  searchStrategyWidth = 10,
+  nrBins = 8,
+  nrThreads = 1
+){
+  subgroupdiscovery(
+    src = src,
+    targetColumn = targetColumn,
+    targetType = .subdisc.TargetType("SINGLE_NUMERIC"),
+    qualityMeasure = .subdisc.QualityMeasure("EXPLAINED_VARIANCE"),
+    qualityMeasureMinimum = qualityMeasureMinimum,
+    searchDepth = searchDepth,
+    minimumCoverage = minimumCoverage,
+    maximumCoverageFraction = maximumCoverageFraction,
+    maximumSubgroups = maximumSubgroups,
+    maximumTime = maximumTime,
+    searchStrategy = searchStrategy,
+    nominalSets = nominalSets,
+    numericOperatorSetting = numericOperatorSetting,
+    numericStrategy = numericStrategy,
+    searchStrategyWidth = searchStrategyWidth,
+    nrBins = nrBins,
+    nrThreads = nrThreads
+  )
+}


### PR DESCRIPTION
# Wrapper for R

This is some base implementation of the wrapper for R.  This is a work-in-progress and the interface/code will probably change a lot.  The code will also need to become a proper R package/library and be documented.

For now, the two first examples from `EndToEndTest.java` are available and (somewhat) working. The third one will need more work and thinking on what the interface should look like. 

I have some questions for @ArnoKnobbe before continuing. 

## Interface

I chose to create specific functions for each kind of search. I created two such function `.subdisc.single_nominal.cortana_quality` and  `.subdisc.single_numeric.explained_variance` offering different default values and calling a more general function (`subgroupdiscovery`). The names and structure are subject to change. The function `subgroupdiscovery` can also be used directly. 

## Test 1

### Working example

From `example.R`
```R
# Simple example based on EndToEndTest.java
source("subdisc.R")

testdatafile = "../src/test/resources/adult.txt"

testAdult1 <- .subdisc.single_nominal.cortana_quality(
  src = testdatafile,
  targetColumn = 14,
  targetValue = "gr50K"
)
```
This will create a `SubgroupSet` encapsulated in a rJava object. This object is not particularly "user-friendly` to use in R. 
 
It is possible to get some information from that object using
```R
df1 <- .subdisc.SubgroupSet.tibble(testAdult1))
```
This create a data frame (from the tibble library) containing
```
# A tibble: 10 × 10
   Subgroup                              Coverage Depth FalsePositiveRate    ID MeasureValue PValue SecondaryStatistic TertiaryStatistic TruePositiveRare
   <chr>                                    <int> <int>             <dbl> <int>        <dbl>  <dbl>              <dbl>             <dbl>            <dbl>
 1 marital-status = 'Married-civ-spouse'      443     1           0.323       1        0.518    NaN              0.440               195            0.841
 2 relationship = 'Husband'                   376     1           0.271       2        0.453    NaN              0.447               168            0.724
 3 education-num >= 11.0                      327     1           0.243       3        0.360    NaN              0.428               140            0.603
 4 age >= 33.0                                616     1           0.534       4        0.354    NaN              0.334               206            0.888
 5 hours-per-week >= 43.0                     268     1           0.214       5        0.235    NaN              0.388               104            0.448
 6 occupation = 'Exec-managerial'             124     1           0.0729      6        0.220    NaN              0.548                68            0.293
 7 sex = 'Male'                               671     1           0.625       7        0.198    NaN              0.285               191            0.823
 8 education = 'Bachelors'                    166     1           0.121       8        0.194    NaN              0.440                73            0.315
 9 capital-gain >= 4386.0                      50     1           0.00911     9        0.176    NaN              0.86                 43            0.185
10 occupation = 'Prof-specialty'              124     1           0.0951     10        0.125    NaN              0.411                51            0.220
```
It is also possible to call the function with other parameters. The function signature is: 
```R
.subdisc.single_nominal.cortana_quality <- function(
  src,
  targetColumn,
  targetValue,
  qualityMeasureMinimum = 0.1,
  searchDepth = 1,
  minimumCoverage = 2,
  maximumCoverageFraction = 1.0,
  maximumSubgroups = 1000,
  maximumTime = 1000,
  searchStrategy = .subdisc.SearchStrategy("BEAM"),
  nominalSets = FALSE,
  numericOperatorSetting = .subdisc.NumericOperatorSetting("NORMAL"),
  numericStrategy = .subdisc.NumericStrategy("NUMERIC_BEST"),
  searchStrategyWidth = 10,
  nrBins = 8,
  nrThreads = 1
) 
```

### Questions

 - In Java, the call to `Process.runSubgroupDiscovery` return a `SubgroupDiscovery` object. Is there relevant information that should be available to the users in that object or everything is contained in the `SubgroupSet` returned by `SubgroupDiscovery.getResults()`? 
- Similarly, is there relevant information in the object `SubgroupSet` that should be available or everything is in the `Subgroup` that it contains?  
- The wrapper can create a data frame that gives access to the information from the `Subgroup`. The fields extracted in the current code are : Subgroup, Coverage, Depth, FalsePositiveRate, ID, MeasureValue, PValue, SecondaryStatistic, TertiaryStatistic and TruePositiveRare. Is there more that should be available or some that should be removed? 

## Test 2

```R
# Simple example based on EndToEndTest.java
source("subdisc.R")

testdatafile = "../src/test/resources/adult.txt"
testAdult2 <- .subdisc.single_numeric.explained_variance(
  src = testdatafile,
  targetColumn = 0,
)

print(.subdisc.SubgroupSet.tibble(testAdult2))
```
```
# A tibble: 3 × 10
  Subgroup                         Coverage Depth FalsePositiveRate    ID MeasureValue PValue SecondaryStatistic TertiaryStatistic TruePositiveRare
  <chr>                               <int> <int>             <dbl> <int>        <dbl>  <dbl>              <dbl>             <dbl>            <dbl>
1 marital-status = 'Never-married'      344     1                 0     1        0.255    NaN               28.7             11.0                 0
2 relationship = 'Own-child'            151     1                 0     2        0.198    NaN               24.0              7.11                0
3 relationship = 'Husband'              376     1                 0     3        0.100    NaN               43.5             11.7                 0
```
The signature of the function is
```R
.subdisc.single_nominal.cortana_quality <- function(
  src,
  targetColumn,
  targetValue,
  qualityMeasureMinimum = 0.1,
  searchDepth = 1,
  minimumCoverage = 2,
  maximumCoverageFraction = 1.0,
  maximumSubgroups = 1000,
  maximumTime = 1000,
  searchStrategy = .subdisc.SearchStrategy("BEAM"),
  nominalSets = FALSE,
  numericOperatorSetting = .subdisc.NumericOperatorSetting("NORMAL"),
  numericStrategy = .subdisc.NumericStrategy("NUMERIC_BEST"),
  searchStrategyWidth = 10,
  nrBins = 8,
  nrThreads = 1
) 
```
### Questions

- The output of Cortana indicates that there are 3 subgroups and 90 candidates. The rJava function that I use to create the array of `Subgroup` only gives access to the 3 subgroups, I imagine because of the tree structure of the data. Can you explain the difference between the subgroups and the candidates, and if we need to give access to the candidates? 

## Test 3

This one is more complex to implement and will need more thinking.

### Question

- Can you explain the differences between `QM` and `QualityMeasure`? For me, they seem to be the same thing, but `QM` is some default implementation that can be tweaked with `QualityMeasure`. 
- In the DFD computation what should be parameterizable? In other words, in that code
```Java
//DFD computation
int aPositiveCount = aTC.getPrimaryTarget().countValues(aTargetValue, null);
QualityMeasure aQualityMeasure = new QualityMeasure(anSP.getQualityMeasure(), aTable.getNrRows(), aPositiveCount);
Validation aValidation = new Validation(anSP, aTable, null, aQualityMeasure);
anSP.setQualityMeasureMinimum(aValidation.getSignWithSwapRand(100));
```
What the users should be able to change?


## Final question

I'm trying to create an interface for Cortana that is really simple and straightforward by hiding a lot of the boilerplate and creating simple functions. Is it the right approach or you would prefer a closer 1-1 transposition of the classes and functions of Cortana? 
 